### PR TITLE
🔧 approval-jobのjobはmaster,developmentブランチのみ許可する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,11 @@ workflows:
           type: approval
           requires:
             - slack/approval-notification
+          filters:
+            branches:
+              only:
+                - development
+                - master
       - deploy-heroku-development:
           requires:
             - approval-job


### PR DESCRIPTION
ドキュメントの修正をしている最中にいちいちSlackにデプロイ通知が来てうざいため、デプロイ通知がくるのはmasterとdevelopmentoのみにする