### PR TITLE
🚨 Dockerの静的解析ツール hadolint の実装

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
   heroku: circleci/heroku@1.0.1
+  docker: circleci/docker@1.0.1
 executors:
   base:
     docker:
@@ -237,6 +238,12 @@ workflows:
     jobs:
       - setup
       - lint:
+          requires:
+            - setup
+      # 詳しくはドキュメントを確認
+      #   https://circleci.com/orbs/registry/orb/circleci/docker
+      - docker/hadolint:
+          dockerfiles: .dockerdev/Dockerfile
           requires:
             - setup
       - test:

--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -7,6 +7,11 @@ ARG NODE_MAJOR
 ARG YARN_VERSION
 ARG BUNDLER_VERSION
 
+# パイプライン内のコマンドがエラーとなった時に中断するオプション
+#   これがないとパイプライン時に途中で失敗しているが最後が成功しているような時は
+#   成功とみなされてしまうため、この設定が必要である
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Common dependencies
 # DEBIAN_FRONTEND=noninteractive
 #   インストール時の対話などで処理が止まってしまう箇所をスキップしてくれる
@@ -19,6 +24,7 @@ ARG BUNDLER_VERSION
 #   特定のDockerレイヤにゴミを残さないための設定(http://docs.docker.jp/engine/userguide/storagedriver/imagesandcontainers.html#id3)
 #   取得したパッケージファイルのローカルリポジトリ、インストール中に作成されたすべての
 #   一時ファイルやログをクリーンアップする
+# hadolint ignore=DL3008
 RUN apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     build-essential \
@@ -49,6 +55,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 # `.dockerdev/Aptfile` ここにインストールしたいものを書いておくことで追加でDocker内で使用できるようになる
 # Aptfileを別ファイルとして切り出すことによってプロジェクトごとの依存関係を無くせる（Dockerfileの使いまわしが可能になる）
 COPY .dockerdev/Aptfile /tmp/Aptfile
+# hadolint ignore=SC2002,SC2046,DL3008
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     libpq-dev \

--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -22,7 +22,10 @@ do
       RUBYOPT=-EUTF-8 bundle exec brakeman
       brakeman=$?
 
-      exit $(($rubocop || $railsBestPractices || $brakeman))
+      hadolint .dockerdev/Dockerfile
+      hadolint=$?
+
+      exit $(($rubocop || $railsBestPractices || $brakeman || $hadolint))
     fi
   done
 done

--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ Docker内ではよく使う [Redis](https://github.com/redis/redis-rb/)、[Sidek
 
 ### 静的コード解析ツール
 
-コードを一定の品質に保つために静的コード解析ツールを以下の３つが導入済みになっています
+コードを一定の品質に保つために静的コード解析ツールを以下の４つが導入済みになっています
 
 - [Rubocop](https://github.com/rubocop-hq/rubocop)(Rubyの静的コードアナライザー及びコードフォーマッター)
 - [Rails Best Practices](https://github.com/flyerhzm/rails_best_practices)(Railsのベストプラクティスを教えてくれる)
 - [Brakeman](https://github.com/presidentbeef/brakeman)(セキュリティの脆弱性チェック)
+- [hadolint](https://github.com/hadolint/hadolint)(Dockerfileの静的コード解析)
 
 ### CI（継続的インテグレーション）/CD（継続的デリバリー）環境 - Lint/Test/Deploy
 


### PR DESCRIPTION
## 概要

Dockerfileを常に一定の基準で保たれるようにするためにDockerfile用の静的コード解析を追加する

## 修正内容

- CircleCI に hadolint を追加し Dockerfileも静的コード解析されるようにする
- hadolint の指摘通りにDockerfileを修正
    - 修正出来ないところは一旦放置する

## 確認事項

- [x] CIが通過していること
