### PR TITLE
🔧 CircleCIでデプロイの承認JOBの色を黄色に変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,6 +254,7 @@ workflows:
             - setup
       - slack/approval-notification:
           message: ':circleci-pass: $CIRCLE_BRANCH ブランチのデプロイ準備が整っています\n:github_octocat: User: $CIRCLE_USERNAME\nデプロイを実行する場合は *Approve* を押してください'
+          color: '#FFFF66'
           requires:
             - lint
             - test


### PR DESCRIPTION
## 概要

デプロイ承認JOBのSlack通知の色を変更する

## 修正内容

わかりやすいように 青 → 黃 に変更

### 変更前

<img width="635" alt="スクリーンショット 2020-06-08 8 30 46" src="https://user-images.githubusercontent.com/14287054/83982558-71d69980-a962-11ea-93fd-76270259fd8f.png">

### 変更後

<img width="635" alt="スクリーンショット 2020-06-08 8 30 25" src="https://user-images.githubusercontent.com/14287054/83982550-684d3180-a962-11ea-8e3b-6c9e7407a42c.png">

## 確認事項

- [x] CIが通過していること
