### PR TITLE
🔧  Add circleci parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,7 @@ jobs:
       - linter
   test:
     executor: base
+    parallelism: 2
     steps:
       - using-workspace
       - ruby/install-deps


### PR DESCRIPTION
## 概要

テストの並列実行機能を試す！
基本的には以下の記事を参考に実装したというか設定を追加しただけ……思った以上に簡単にできてしまった。

- [テストの並列実行 - CircleCI](https://circleci.com/docs/ja/2.0/parallelism-faster-jobs/#)

## 修正内容

parallelism の設定を追加しただけ

### テストの並列実行を行うために必要なこと

- `store_test_results` を使用してテストのメタデータを追加する
- `store_test_results` を設定することでタイミングデータが作成され、それを元にいい感じでテストの並列を行ってくれます
- タイミングデータによるテスト分割を行う
- テスト分割を行ったものをそのまま実行する

### Orbs を使用している場合

[circleci/ruby@1.2.0](https://circleci.com/developer/ja/orbs/orb/circleci/ruby#commands-rspec-test) の orbs では既にテストのメタデータの収集ができている状態だし、テストの分割までできているので parallelism の設定を追加するだけで問題なかった

```yml
description: >-
  Test with RSpec. You have to add `gem 'rspec_junit_formatter'` to your
  Gemfile. Enable parallelism on CircleCI for faster testing.
parameters:
  label:
    default: RSpec Tests
    description: Task label
    type: string
  out-path:
    default: /tmp/test-results/rspec
    description: >-
      Where to save the rspec.xml file. Will automatically be saved to
      test_results and artifacts on CircleCI.
    type: string
steps:
  - run:
      command: >
        mkdir -p <<parameters.out-path>>

        TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests
        split --split-by=timings)

        bundle exec rspec $TESTFILES --profile 10 --format RspecJunitFormatter
        --out <<parameters.out-path>>/results.xml --format progress
      name: <<parameters.label>>
  - store_test_results:
      path: <<parameters.out-path>>
  - store_artifacts:
      destination: test-results
      path: <<parameters.out-path>>
```

### 並列実行ができていると

以下のような記述が表示されます。

![スクリーンショット 2021-12-13 8 31 18](https://user-images.githubusercontent.com/14287054/145734163-cb5021e2-50f1-4766-ab94-98138a365de9.png)

## 確認事項

- [ ] CIが通過していること
